### PR TITLE
Fix potential conflicts with remapped keys

### DIFF
--- a/autoload/ctrlp/cmdpalette.vim
+++ b/autoload/ctrlp/cmdpalette.vim
@@ -85,10 +85,10 @@ endfunction
 "  a:str    the selected string
 func! ctrlp#cmdpalette#accept(mode, str)
   call ctrlp#exit()
-  call feedkeys(':')
-  call feedkeys(split(a:str, '\t')[0])
+  call feedkeys(':', 'n')
+  call feedkeys(split(a:str, '\t')[0], 'n')
   if g:ctrlp_cmdpalette_execute == 1
-    call feedkeys("\<CR>")
+    call feedkeys("\<CR>", 'n')
   endif
 endfunc
 


### PR DESCRIPTION
Since I've mapped my `;` key to `:` I've also done the opposite and mapped `:` to `;`.

As it currently is for me, when this plugin attempts to type the `:` for a selected command it gets remapped to `;` and so I don't get the expected behaviour.

This patch fixes the issue by passing a flag to `feedkeys()` that prevents this remapping.
