### PR TITLE
Fix CtrlP window not hiding right away

### DIFF
--- a/autoload/ctrlp/cmdpalette.vim
+++ b/autoload/ctrlp/cmdpalette.vim
@@ -85,6 +85,7 @@ endfunction
 "  a:str    the selected string
 func! ctrlp#cmdpalette#accept(mode, str)
   call ctrlp#exit()
+  redraw
   call feedkeys(':')
   call feedkeys(split(a:str, '\t')[0])
   if g:ctrlp_cmdpalette_execute == 1


### PR DESCRIPTION
Quick fix to hide the CtrlP window before putting the command in the command line instead of after the command is executed.
