### PR TITLE
improve init performance

### DIFF
--- a/autoload/ctrlp/cmdpalette.vim
+++ b/autoload/ctrlp/cmdpalette.vim
@@ -38,6 +38,7 @@ endif
 
 python << endofpython
 import vim
+import json
 
 # obtain the internal commands (file distributed with the plugin)
 path_to_script = vim.eval('expand("<sfile>")')
@@ -51,15 +52,14 @@ vim.command('silent command')
 vim.command('redir END')
 
 # convert to list, remove empties, discard 4 first columns and take first word
-custom_commands = [x[4:].split()[0] + '\\t(custom command)'
+custom_commands = [x[4:].split()[0] + '\t(custom command)'
                    for x in vim.eval('custom_commands').split('\n')
                    if x.strip()]
 # remove header
-if custom_commands[0].split('\\t')[0] == 'Name':
+if custom_commands[0].split('\t')[0] == 'Name':
     del custom_commands[0]
 
-for command in custom_commands + internal_commands:
-    vim.eval('add(s:cmdpalette_commands, "%s")' % command)
+vim.command('let s:cmdpalette_commands = %s' % json.dumps(internal_commands + custom_commands))
 endofpython
 
 

--- a/autoload/ctrlp/internal_commands.txt
+++ b/autoload/ctrlp/internal_commands.txt
@@ -1,519 +1,519 @@
-!\t:! filter lines or execute an external command
-!!\t:!! repeat last \":!\" command
-#\t:# same as \":number\"
-&\t:& repeat last \":substitute\"
-star\t:* execute contents of a register
-<\t:< shift lines one 'shiftwidth' left
-=\t:= print the cursor line number
->\t:> shift lines one 'shiftwidth' right
-@\t:@ execute contents of a register
-@@\t:@@ repeat the previous \":@\"
-Next\t:N[ext] go to previous file in the argument list
-Print\t:P[rint] print lines
-X\t:X ask for encryption key
-append\t:a[ppend] append text
-abbreviate\t:ab[breviate] enter abbreviation
-abclear\t:abc[lear] remove all abbreviations
-aboveleft\t:abo[veleft] make split window appear left or above
-all\t:al[l] open a window for each file in the argument list
-amenu\t:am[enu] enter new menu item for all modes
-anoremenu\t:an[oremenu] enter a new menu for all modes that will not be remapped
-args\t:ar[gs] print the argument list
-argadd\t:arga[dd] add items to the argument list
-argdelete\t:argd[elete] delete items from the argument list
-argedit\t:arge[dit] add item to the argument list and edit it
-argdo\t:argdo do a command on all items in the argument list
-argglobal\t:argg[lobal] define the global argument list
-arglocal\t:argl[ocal] define a local argument list
-argument\t:argu[ment] go to specific file in the argument list
-ascii\t:as[cii] print ascii value of character under the cursor
-autocmd\t:au[tocmd] enter or show autocommands
-augroup\t:aug[roup] select the autocommand group to use
-aunmenu\t:aun[menu] remove menu for all modes
-buffer\t:b[uffer] go to specific buffer in the buffer list
-bNext\t:bN[ext] go to previous buffer in the buffer list
-ball\t:ba[ll] open a window for each buffer in the buffer list
-badd\t:bad[d] add buffer to the buffer list
-bdelete\t:bd[elete] remove a buffer from the buffer list
-behave\t:be[have] set mouse and selection behavior
-belowright\t:bel[owright] make split window appear right or below
-bfirst\t:bf[irst] go to first buffer in the buffer list
-blast\t:bl[ast] go to last buffer in the buffer list
-bmodified\t:bm[odified] go to next buffer in the buffer list that has been modified
-bnext\t:bn[ext] go to next buffer in the buffer list
-botright\t:bo[tright] make split window appear at bottom or far right
-bprevious\t:bp[revious] go to previous buffer in the buffer list
-brewind\t:br[ewind] go to first buffer in the buffer list
-break\t:brea[k] break out of while loop
-breakadd\t:breaka[dd] add a debugger breakpoint
-breakdel\t:breakd[el] delete a debugger breakpoint
-breaklist\t:breakl[ist] list debugger breakpoints
-browse\t:bro[wse] use file selection dialog
-bufdo\t:bufdo execute command in each listed buffer
-buffers\t:buffers list all files in the buffer list
-bunload\t:bun[load] unload a specific buffer
-bwipeout\t:bw[ipeout] really delete a buffer
-change\t:c[hange] replace a line or series of lines
-cNext\t:cN[ext] go to previous error
-cNfile\t:cNf[ile] go to last error in previous file
-cabbrev\t:ca[bbrev] like \":abbreviate\" but for Command-line mode
-cabclear\t:cabc[lear] clear all abbreviations for Command-line mode
-caddbuffer\t:caddb[uffer] add errors from buffer
-caddexpr\t:cad[dexpr] add errors from expr
-caddfile\t:caddf[ile] add error message to current quickfix list
-call\t:cal[l] call a function
-catch\t:cat[ch] part of a :try command
-cbuffer\t:cb[uffer] parse error messages and jump to first error
-cc\t:cc go to specific error
-cclose\t:ccl[ose] close quickfix window
-cd\t:cd change directory
-center\t:ce[nter] format lines at the center
-cexpr\t:cex[pr] read errors from expr and jump to first
-cfile\t:cf[ile] read file with error messages and jump to first
-cfirst\t:cfir[st] go to the specified error, default first one
-cgetbuffer\t:cgetb[uffer] get errors from buffer
-cgetexpr\t:cgete[xpr] get errors from expr
-cgetfile\t:cg[etfile] read file with error messages
-changes\t:cha[nges] print the change list
-chdir\t:chd[ir] change directory
-checkpath\t:che[ckpath] list included files
-checktime\t:checkt[ime] check timestamp of loaded buffers
-clist\t:cl[ist] list all errors
-clast\t:cla[st] go to the specified error, default last one
-close\t:clo[se] close current window
-cmap\t:cm[ap] like \":map\" but for Command-line mode
-cmapclear\t:cmapc[lear] clear all mappings for Command-line mode
-cmenu\t:cme[nu] add menu for Command-line mode
-cnext\t:cn[ext] go to next error
-cnewer\t:cnew[er] go to newer error list
-cnfile\t:cnf[ile] go to first error in next file
-cnoremap\t:cno[remap] like \":noremap\" but for Command-line mode
-cnoreabbrev\t:cnorea[bbrev] like \":noreabbrev\" but for Command-line mode
-cnoremenu\t:cnoreme[nu] like \":noremenu\" but for Command-line mode
-copy\t:co[py] copy lines
-colder\t:col[der] go to older error list
-colorscheme\t:colo[rscheme] load a specific color scheme
-command\t:com[mand] create user-defined command
-comclear\t:comc[lear] clear all user-defined commands
-compiler\t:comp[iler] do settings for a specific compiler
-continue\t:con[tinue] go back to :while
-confirm\t:conf[irm] prompt user when confirmation required
-copen\t:cope[n] open quickfix window
-cprevious\t:cp[revious] go to previous error
-cpfile\t:cpf[ile] go to last error in previous file
-cquit\t:cq[uit] quit Vim with an error code
-crewind\t:cr[ewind] go to the specified error, default first one
-cscope\t:cs[cope] execute cscope command
-cstag\t:cst[ag] use cscope to jump to a tag
-cunmap\t:cu[nmap] like \":unmap\" but for Command-line mode
-cunabbrev\t:cuna[bbrev] like \":unabbrev\" but for Command-line mode
-cunmenu\t:cunme[nu] remove menu for Command-line mode
-cwindow\t:cw[indow] open or close quickfix window
-delete\t:d[elete] delete lines
-delmarks\t:delm[arks] delete marks
-debug\t:deb[ug] run a command in debugging mode
-debuggreedy\t:debugg[reedy] read debug mode commands from normal input
-delcommand\t:delc[ommand] delete user-defined command
-delfunction\t:delf[unction] delete a user function
-diffupdate\t:dif[fupdate] update 'diff' buffers
-diffget\t:diffg[et] remove differences in current buffer
-diffoff\t:diffo[ff] switch off diff mode
-diffpatch\t:diffp[atch] apply a patch and show differences
-diffput\t:diffpu[t] remove differences in other buffer
-diffsplit\t:diffs[plit] show differences with another file
-diffthis\t:diffthis make current window a diff window
-digraphs\t:dig[raphs] show or enter digraphs
-display\t:di[splay] display registers
-djump\t:dj[ump] jump to #define
-dlist\t:dl[ist] list #defines
-doautocmd\t:do[autocmd] apply autocommands to current buffer
-doautoall\t:doautoa[ll] apply autocommands for all loaded buffers
-drop\t:dr[op] jump to window editing file or edit file in current window
-dsearch\t:ds[earch] list one #define
-dsplit\t:dsp[lit] split window and jump to #define
-edit\t:e[dit] edit a file
-earlier\t:ea[rlier] go to older change, undo
-echo\t:ec[ho] echoes the result of expressions
-echoerr\t:echoe[rr] like :echo, show like an error and use history
-echohl\t:echoh[l] set highlighting for echo commands
-echomsg\t:echom[sg] same as :echo, put message in history
-echon\t:echon same as :echo, but without <EOL>
-else\t:el[se] part of an :if command
-elseif\t:elsei[f] part of an :if command
-emenu\t:em[enu] execute a menu by name
-endif\t:en[dif] end previous :if
-endfor\t:endfo[r] end previous :for
-endfunction\t:endf[unction] end of a user function
-endtry\t:endt[ry] end previous :try
-endwhile\t:endw[hile] end previous :while
-enew\t:ene[w] edit a new, unnamed buffer
-ex\t:ex same as \":edit\"
-execute\t:exe[cute] execute result of expressions
-exit\t:exi[t] same as \":xit\"
-exusage\t:exu[sage] overview of Ex commands
-file\t:f[ile] show or set the current file name
-files\t:files list all files in the buffer list
-filetype\t:filet[ype] switch file type detection on/off
-find\t:fin[d] find file in 'path' and edit it
-finally\t:fina[lly] part of a :try command
-finish\t:fini[sh] quit sourcing a Vim script
-first\t:fir[st] go to the first file in the argument list
-fixdel\t:fix[del] set key code of <Del>
-fold\t:fo[ld] create a fold
-foldclose\t:foldc[lose] close folds
-folddoopen\t:foldd[oopen] execute command on lines not in a closed fold
-folddoclosed\t:folddoc[losed] execute command on lines in a closed fold
-foldopen\t:foldo[pen] open folds
-for\t:for for loop
-function\t:fu[nction] define a user function
-global\t:g[lobal] execute commands for matching lines
-goto\t:go[to] go to byte in the buffer
-grep\t:gr[ep] run 'grepprg' and jump to first match
-grepadd\t:grepa[dd] like :grep, but append to current list
-gui\t:gu[i] start the GUI
-gvim\t:gv[im] start the GUI
-hardcopy\t:ha[rdcopy] send text to the printer
-help\t:h[elp] open a help window
-helpfind\t:helpf[ind] dialog to open a help window
-helpgrep\t:helpg[rep] like \":grep\" but searches help files
-helptags\t:helpt[ags] generate help tags for a directory
-highlight\t:hi[ghlight] specify highlighting methods
-hide\t:hid[e] hide current buffer for a command
-history\t:his[tory] print a history list
-insert\t:i[nsert] insert text
-iabbrev\t:ia[bbrev] like \":abbrev\" but for Insert mode
-iabclear\t:iabc[lear] like \":abclear\" but for Insert mode
-if\t:if execute commands when condition met
-ijump\t:ij[ump] jump to definition of identifier
-ilist\t:il[ist] list lines where identifier matches
-imap\t:im[ap] like \":map\" but for Insert mode
-imapclear\t:imapc[lear] like \":mapclear\" but for Insert mode
-imenu\t:ime[nu] add menu for Insert mode
-inoremap\t:ino[remap] like \":noremap\" but for Insert mode
-inoreabbrev\t:inorea[bbrev] like \":noreabbrev\" but for Insert mode
-inoremenu\t:inoreme[nu] like \":noremenu\" but for Insert mode
-intro\t:int[ro] print the introductory message
-isearch\t:is[earch] list one line where identifier matches
-isplit\t:isp[lit] split window and jump to definition of identifier
-iunmap\t:iu[nmap] like \":unmap\" but for Insert mode
-iunabbrev\t:iuna[bbrev] like \":unabbrev\" but for Insert mode
-iunmenu\t:iunme[nu] remove menu for Insert mode
-join\t:j[oin] join lines
-jumps\t:ju[mps] print the jump list
-k\t:k set a mark
-keepalt\t:keepa[lt] following command keeps the alternate file
-keepmarks\t:kee[pmarks] following command keeps marks where they are
-keepjumps\t:keepj[umps] following command keeps jumplist and marks
-lNext\t:lN[ext] go to previous entry in location list
-lNfile\t:lNf[ile] go to last entry in previous file
-list\t:l[ist] print lines
-laddexpr\t:lad[dexpr] add locations from expr
-laddbuffer\t:laddb[uffer] add locations from buffer
-laddfile\t:laddf[ile] add locations to current location list
-last\t:la[st] go to the last file in the argument list
-language\t:lan[guage] set the language (locale)
-later\t:lat[er] go to newer change, redo
-lbuffer\t:lb[uffer] parse locations and jump to first location
-lcd\t:lc[d] change directory locally
-lchdir\t:lch[dir] change directory locally
-lclose\t:lcl[ose] close location window
-lcscope\t:lcs[cope] like \":cscope\" but uses location list
-left\t:le[ft] left align lines
-leftabove\t:lefta[bove] make split window appear left or above
-let\t:let assign a value to a variable or option
-lexpr\t:lex[pr] read locations from expr and jump to first
-lfile\t:lf[ile] read file with locations and jump to first
-lfirst\t:lfir[st] go to the specified location, default first one
-lgetbuffer\t:lgetb[uffer] get locations from buffer
-lgetexpr\t:lgete[xpr] get locations from expr
-lgetfile\t:lg[etfile] read file with locations
-lgrep\t:lgr[ep] run 'grepprg' and jump to first match
-lgrepadd\t:lgrepa[dd] like :grep, but append to current list
-lhelpgrep\t:lh[elpgrep] like \":helpgrep\" but uses location list
-ll\t:ll go to specific location
-llast\t:lla[st] go to the specified location, default last one
-llist\t:lli[st] list all locations
-lmake\t:lmak[e] execute external command 'makeprg' and parse error messages
-lmap\t:lm[ap] like \":map!\" but includes Lang-Arg mode
-lmapclear\t:lmapc[lear] like \":mapclear!\" but includes Lang-Arg mode
-lnext\t:lne[xt] go to next location
-lnewer\t:lnew[er] go to newer location list
-lnfile\t:lnf[ile] go to first location in next file
-lnoremap\t:ln[oremap] like \":noremap!\" but includes Lang-Arg mode
-loadkeymap\t:loadk[eymap] load the following keymaps until EOF
-loadview\t:lo[adview] load view for current window from a file
-lockmarks\t:loc[kmarks] following command keeps marks where they are
-lockvar\t:lockv[ar] lock variables
-lolder\t:lol[der] go to older location list
-lopen\t:lope[n] open location window
-lprevious\t:lp[revious] go to previous location
-lpfile\t:lpf[ile] go to last location in previous file
-lrewind\t:lr[ewind] go to the specified location, default first one
-ls\t:ls list all buffers
-ltag\t:lt[ag] jump to tag and add matching tags to the location list
-lunmap\t:lu[nmap] like \":unmap!\" but includes Lang-Arg mode
-lua\t:lua execute Lua command
-luado\t:luad[o] execute Lua command for each line
-luafile\t:luaf[ile] execute Lua script file
-lvimgrep\t:lv[imgrep] search for pattern in files
-lvimgrepadd\t:lvimgrepa[dd] like :vimgrep, but append to current list
-lwindow\t:lw[indow] open or close location window
-move\t:m[ove] move lines
-mark\t:ma[rk] set a mark
-make\t:mak[e] execute external command 'makeprg' and parse error messages
-map\t:map show or enter a mapping
-mapclear\t:mapc[lear] clear all mappings for Normal and Visual mode
-marks\t:marks list all marks
-match\t:mat[ch] define a match to highlight
-menu\t:me[nu] enter a new menu item
-menutranslate\t:menut[ranslate] add a menu translation item
-messages\t:mes[sages] view previously displayed messages
-mkexrc\t:mk[exrc] write current mappings and settings to a file
-mksession\t:mks[ession] write session info to a file
-mkspell\t:mksp[ell] produce .spl spell file
-mkvimrc\t:mkv[imrc] write current mappings and settings to a file
-mkview\t:mkvie[w] write view of current window to a file
-mode\t:mod[e] show or change the screen mode
-mzscheme\t:mz[scheme] execute MzScheme command
-mzfile\t:mzf[ile] execute MzScheme script file
-nbclose\t:nbc[lose] close the current Netbeans session
-nbkey\t:nb[key] pass a key to Netbeans
-nbstart\t:nbs[art] start a new Netbeans session
-next\t:n[ext] go to next file in the argument list
-new\t:new create a new empty window
-nmap\t:nm[ap] like \":map\" but for Normal mode
-nmapclear\t:nmapc[lear] clear all mappings for Normal mode
-nmenu\t:nme[nu] add menu for Normal mode
-nnoremap\t:nn[oremap] like \":noremap\" but for Normal mode
-nnoremenu\t:nnoreme[nu] like \":noremenu\" but for Normal mode
-noautocmd\t:noa[utocmd] following command don't trigger autocommands
-noremap\t:no[remap] enter a mapping that will not be remapped
-nohlsearch\t:noh[lsearch] suspend 'hlsearch' highlighting
-noreabbrev\t:norea[bbrev] enter an abbreviation that will not be remapped
-noremenu\t:noreme[nu] enter a menu that will not be remapped
-normal\t:norm[al] execute Normal mode commands
-number\t:nu[mber] print lines with line number
-nunmap\t:nun[map] like \":unmap\" but for Normal mode
-nunmenu\t:nunme[nu] remove menu for Normal mode
-oldfiles\t:ol[dfiles] list files that have marks in the viminfo file
-open\t:o[pen] start open mode (not implemented)
-omap\t:om[ap] like \":map\" but for Operator-pending mode
-omapclear\t:omapc[lear] remove all mappings for Operator-pending mode
-omenu\t:ome[nu] add menu for Operator-pending mode
-only\t:on[ly] close all windows except the current one
-onoremap\t:ono[remap] like \":noremap\" but for Operator-pending mode
-onoremenu\t:onoreme[nu] like \":noremenu\" but for Operator-pending mode
-options\t:opt[ions] open the options-window
-ounmap\t:ou[nmap] like \":unmap\" but for Operator-pending mode
-ounmenu\t:ounme[nu] remove menu for Operator-pending mode
-ownsyntax\t:ow[nsyntax] set new local syntax highlight for this window
-pclose\t:pc[lose] close preview window
-pedit\t:ped[it] edit file in the preview window
-perl\t:pe[rl] execute Perl command
-print\t:p[rint] print lines
-profdel\t:profd[el] stop profiling a function or script
-profile\t:prof[ile] profiling functions and scripts
-promptfind\t:pro[mptfind] open GUI dialog for searching
-promptrepl\t:promptr[epl] open GUI dialog for search/replace
-perldo\t:perld[o] execute Perl command for each line
-pop\t:po[p] jump to older entry in tag stack
-popup\t:pop[up] popup a menu by name
-ppop\t:pp[op] \":pop\" in preview window
-preserve\t:pre[serve] write all text to swap file
-previous\t:prev[ious] go to previous file in argument list
-psearch\t:ps[earch] like \":ijump\" but shows match in preview window
-ptag\t:pt[ag] show tag in preview window
-ptNext\t:ptN[ext] :tNext in preview window
-ptfirst\t:ptf[irst] :trewind in preview window
-ptjump\t:ptj[ump] :tjump and show tag in preview window
-ptlast\t:ptl[ast] :tlast in preview window
-ptnext\t:ptn[ext] :tnext in preview window
-ptprevious\t:ptp[revious] :tprevious in preview window
-ptrewind\t:ptr[ewind] :trewind in preview window
-ptselect\t:pts[elect] :tselect and show tag in preview window
-put\t:pu[t] insert contents of register in the text
-pwd\t:pw[d] print current directory
-py3\t:py3 execute Python 3 command
-python3\t:python3 same as :py3
-py3file\t:py3f[ile] execute Python 3 script file
-python\t:py[thon] execute Python command
-pyfile\t:pyf[ile] execute Python script file
-quit\t:q[uit] quit current window (when one window quit Vim)
-quitall\t:quita[ll] quit Vim
-qall\t:qa[ll] quit Vim
-read\t:r[ead] read file into the text
-recover\t:rec[over] recover a file from a swap file
-redo\t:red[o] redo one undone change
-redir\t:redi[r] redirect messages to a file or register
-redraw\t:redr[aw] force a redraw of the display
-redrawstatus\t:redraws[tatus] force a redraw of the status line(s)
-registers\t:reg[isters] display the contents of registers
-resize\t:res[ize] change current window height
-retab\t:ret[ab] change tab size
-return\t:retu[rn] return from a user function
-rewind\t:rew[ind] go to the first file in the argument list
-right\t:ri[ght] right align text
-rightbelow\t:rightb[elow] make split window appear right or below
-ruby\t:rub[y] execute Ruby command
-rubydo\t:rubyd[o] execute Ruby command for each line
-rubyfile\t:rubyf[ile] execute Ruby script file
-rundo\t:rund[o] read undo information from a file
-runtime\t:ru[ntime] source vim scripts in 'runtimepath'
-rviminfo\t:rv[iminfo] read from viminfo file
-substitute\t:s[ubstitute] find and replace text
-sNext\t:sN[ext] split window and go to previous file in argument list
-sandbox\t:san[dbox] execute a command in the sandbox
-sargument\t:sa[rgument] split window and go to specific file in argument list
-sall\t:sal[l] open a window for each file in argument list
-saveas\t:sav[eas] save file under another name.
-sbuffer\t:sb[uffer] split window and go to specific file in the buffer list
-sbNext\t:sbN[ext] split window and go to previous file in the buffer list
-sball\t:sba[ll] open a window for each file in the buffer list
-sbfirst\t:sbf[irst] split window and go to first file in the buffer list
-sblast\t:sbl[ast] split window and go to last file in buffer list
-sbmodified\t:sbm[odified] split window and go to modified file in the buffer list
-sbnext\t:sbn[ext] split window and go to next file in the buffer list
-sbprevious\t:sbp[revious] split window and go to previous file in the buffer list
-sbrewind\t:sbr[ewind] split window and go to first file in the buffer list
-scriptnames\t:scrip[tnames] list names of all sourced Vim scripts
-scriptencoding\t:scripte[ncoding] encoding used in sourced Vim script
-scscope\t:scs[cope] split window and execute cscope command
-set\t:se[t] show or set options
-setfiletype\t:setf[iletype] set 'filetype', unless it was set already
-setglobal\t:setg[lobal] show global values of options
-setlocal\t:setl[ocal] show or set options locally
-sfind\t:sf[ind] split current window and edit file in 'path'
-sfirst\t:sfir[st] split window and go to first file in the argument list
-shell\t:sh[ell] escape to a shell
-simalt\t:sim[alt] Win32 GUI: simulate Windows ALT key
-sign\t:sig[n] manipulate signs
-silent\t:sil[ent] run a command silently
-sleep\t:sl[eep] do nothing for a few seconds
-slast\t:sla[st] split window and go to last file in the argument list
-smagic\t:sm[agic] :substitute with 'magic'
-smap\t:sma[p] like \":map\" but for Select mode
-smapclear\t:smapc[lear] remove all mappings for Select mode
-smenu\t:sme[nu] add menu for Select mode
-snext\t:sn[ext] split window and go to next file in the argument list
-sniff\t:sni[ff] send request to sniff
-snomagic\t:sno[magic] :substitute with 'nomagic'
-snoremap\t:snor[emap] like \":noremap\" but for Select mode
-snoremenu\t:snoreme[nu] like \":noremenu\" but for Select mode
-sort\t:sor[t] sort lines
-source\t:so[urce] read Vim or Ex commands from a file
-spelldump\t:spelld[ump] split window and fill with all correct words
-spellgood\t:spe[llgood] add good word for spelling
-spellinfo\t:spelli[nfo] show info about loaded spell files
-spellrepall\t:spellr[epall] replace all bad words like last z=
-spellundo\t:spellu[ndo] remove good or bad word
-spellwrong\t:spellw[rong] add spelling mistake
-split\t:sp[lit] split current window
-sprevious\t:spr[evious] split window and go to previous file in the argument list
-srewind\t:sre[wind] split window and go to first file in the argument list
-stop\t:st[op] suspend the editor or escape to a shell
-stag\t:sta[g] split window and jump to a tag
-startinsert\t:star[tinsert] start Insert mode
-startgreplace\t:startg[replace] start Virtual Replace mode
-startreplace\t:startr[eplace] start Replace mode
-stopinsert\t:stopi[nsert] stop Insert mode
-stjump\t:stj[ump] do \":tjump\" and split window
-stselect\t:sts[elect] do \":tselect\" and split window
-sunhide\t:sun[hide] same as \":unhide\"
-sunmap\t:sunm[ap] like \":unmap\" but for Select mode
-sunmenu\t:sunme[nu] remove menu for Select mode
-suspend\t:sus[pend] same as \":stop\"
-sview\t:sv[iew] split window and edit file read-only
-swapname\t:sw[apname] show the name of the current swap file
-syntax\t:sy[ntax] syntax highlighting
-syncbind\t:sync[bind] sync scroll binding
-t\t:t same as \":copy\"
-tNext\t:tN[ext] jump to previous matching tag
-tabNext\t:tabN[ext] go to previous tab page
-tabclose\t:tabc[lose] close current tab page
-tabdo\t:tabdo execute command in each tab page
-tabedit\t:tabe[dit] edit a file in a new tab page
-tabfind\t:tabf[ind] find file in 'path', edit it in a new tab page
-tabfirst\t:tabfir[st] got to first tab page
-tablast\t:tabl[ast] got to last tab page
-tabmove\t:tabm[ove] move tab page to other position
-tabnew\t:tabnew edit a file in a new tab page
-tabnext\t:tabn[ext] go to next tab page
-tabonly\t:tabo[nly] close all tab pages except the current one
-tabprevious\t:tabp[revious] go to previous tab page
-tabrewind\t:tabr[ewind] got to first tab page
-tabs\t:tabs list the tab pages and what they contain
-tab\t:tab create new tab when opening new window
-tag\t:ta[g] jump to tag
-tags\t:tags show the contents of the tag stack
-tcl\t:tc[l] execute Tcl command
-tcldo\t:tcld[o] execute Tcl command for each line
-tclfile\t:tclf[ile] execute Tcl script file
-tearoff\t:te[aroff] tear-off a menu
-tfirst\t:tf[irst] jump to first matching tag
-throw\t:th[row] throw an exception
-tjump\t:tj[ump] like \":tselect\", but jump directly when there is only one match
-tlast\t:tl[ast] jump to last matching tag
-tmenu\t:tm[enu] define menu tooltip
-tnext\t:tn[ext] jump to next matching tag
-topleft\t:to[pleft] make split window appear at top or far left
-tprevious\t:tp[revious] jump to previous matching tag
-trewind\t:tr[ewind] jump to first matching tag
-try\t:try execute commands, abort on error or exception
-tselect\t:ts[elect] list matching tags and select one
-tunmenu\t:tu[nmenu] remove menu tooltip
-undo\t:u[ndo] undo last change(s)
-undojoin\t:undoj[oin] join next change with previous undo block
-undolist\t:undol[ist] list leafs of the undo tree
-unabbreviate\t:una[bbreviate] remove abbreviation
-unhide\t:unh[ide] open a window for each loaded file in the buffer list
-unlet\t:unl[et] delete variable
-unlockvar\t:unlo[ckvar] unlock variables
-unmap\t:unm[ap] remove mapping
-unmenu\t:unme[nu] remove menu
-unsilent\t:uns[ilent] run a command not silently
-update\t:up[date] write buffer if modified
-vglobal\t:v[global] execute commands for not matching lines
-version\t:ve[rsion] print version number and other info
-verbose\t:verb[ose] execute command with 'verbose' set
-vertical\t:vert[ical] make following command split vertically
-vimgrep\t:vim[grep] search for pattern in files
-vimgrepadd\t:vimgrepa[dd] like :vimgrep, but append to current list
-visual\t:vi[sual] same as \":edit\", but turns off \"Ex\" mode
-viusage\t:viu[sage] overview of Normal mode commands
-view\t:vie[w] edit a file read-only
-vmap\t:vm[ap] like \":map\" but for Visual+Select mode
-vmapclear\t:vmapc[lear] remove all mappings for Visual+Select mode
-vmenu\t:vme[nu] add menu for Visual+Select mode
-vnew\t:vne[w] create a new empty window, vertically split
-vnoremap\t:vn[oremap] like \":noremap\" but for Visual+Select mode
-vnoremenu\t:vnoreme[nu] like \":noremenu\" but for Visual+Select mode
-vsplit\t:vs[plit] split current window vertically
-vunmap\t:vu[nmap] like \":unmap\" but for Visual+Select mode
-vunmenu\t:vunme[nu] remove menu for Visual+Select mode
-windo\t:windo execute command in each window
-write\t:w[rite] write to a file
-wNext\t:wN[ext] write to a file and go to previous file in argument list
-wall\t:wa[ll] write all (changed) buffers
-while\t:wh[ile] execute loop for as long as condition met
-winsize\t:wi[nsize] get or set window size (obsolete)
-wincmd\t:winc[md] execute a Window (CTRL-W) command
-winpos\t:winp[os] get or set window position
-wnext\t:wn[ext] write to a file and go to next file in argument list
-wprevious\t:wp[revious] write to a file and go to previous file in argument list
-wq\t:wq write to a file and quit window or Vim
-wqall\t:wqa[ll] write all changed buffers and quit Vim
-wsverb\t:ws[verb] pass the verb to workshop over IPC
-wundo\t:wu[ndo] write undo information to a file
-wviminfo\t:wv[iminfo] write to viminfo file
-xit\t:x[it] write if buffer changed and quit window or Vim
-xall\t:xa[ll] same as \":wqall\"
-xmapclear\t:xmapc[lear] remove all mappings for Visual mode
-xmap\t:xm[ap] like \":map\" but for Visual mode
-xmenu\t:xme[nu] add menu for Visual mode
-xnoremap\t:xn[oremap] like \":noremap\" but for Visual mode
-xnoremenu\t:xnoreme[nu] like \":noremenu\" but for Visual mode
-xunmap\t:xu[nmap] like \":unmap\" but for Visual mode
-xunmenu\t:xunme[nu] remove menu for Visual mode
-yank\t:y[ank] yank lines into a register
-z\t:z print some lines
-~\t:~ repeat last \":substitute\"
+!	:! filter lines or execute an external command
+!!	:!! repeat last `:!` command
+#	:# same as `:number`
+&	:& repeat last `:substitute`
+star	:* execute contents of a register
+<	:< shift lines one 'shiftwidth' left
+=	:= print the cursor line number
+>	:> shift lines one 'shiftwidth' right
+@	:@ execute contents of a register
+@@	:@@ repeat the previous `:@`
+Next	:N[ext] go to previous file in the argument list
+Print	:P[rint] print lines
+X	:X ask for encryption key
+append	:a[ppend] append text
+abbreviate	:ab[breviate] enter abbreviation
+abclear	:abc[lear] remove all abbreviations
+aboveleft	:abo[veleft] make split window appear left or above
+all	:al[l] open a window for each file in the argument list
+amenu	:am[enu] enter new menu item for all modes
+anoremenu	:an[oremenu] enter a new menu for all modes that will not be remapped
+args	:ar[gs] print the argument list
+argadd	:arga[dd] add items to the argument list
+argdelete	:argd[elete] delete items from the argument list
+argedit	:arge[dit] add item to the argument list and edit it
+argdo	:argdo do a command on all items in the argument list
+argglobal	:argg[lobal] define the global argument list
+arglocal	:argl[ocal] define a local argument list
+argument	:argu[ment] go to specific file in the argument list
+ascii	:as[cii] print ascii value of character under the cursor
+autocmd	:au[tocmd] enter or show autocommands
+augroup	:aug[roup] select the autocommand group to use
+aunmenu	:aun[menu] remove menu for all modes
+buffer	:b[uffer] go to specific buffer in the buffer list
+bNext	:bN[ext] go to previous buffer in the buffer list
+ball	:ba[ll] open a window for each buffer in the buffer list
+badd	:bad[d] add buffer to the buffer list
+bdelete	:bd[elete] remove a buffer from the buffer list
+behave	:be[have] set mouse and selection behavior
+belowright	:bel[owright] make split window appear right or below
+bfirst	:bf[irst] go to first buffer in the buffer list
+blast	:bl[ast] go to last buffer in the buffer list
+bmodified	:bm[odified] go to next buffer in the buffer list that has been modified
+bnext	:bn[ext] go to next buffer in the buffer list
+botright	:bo[tright] make split window appear at bottom or far right
+bprevious	:bp[revious] go to previous buffer in the buffer list
+brewind	:br[ewind] go to first buffer in the buffer list
+break	:brea[k] break out of while loop
+breakadd	:breaka[dd] add a debugger breakpoint
+breakdel	:breakd[el] delete a debugger breakpoint
+breaklist	:breakl[ist] list debugger breakpoints
+browse	:bro[wse] use file selection dialog
+bufdo	:bufdo execute command in each listed buffer
+buffers	:buffers list all files in the buffer list
+bunload	:bun[load] unload a specific buffer
+bwipeout	:bw[ipeout] really delete a buffer
+change	:c[hange] replace a line or series of lines
+cNext	:cN[ext] go to previous error
+cNfile	:cNf[ile] go to last error in previous file
+cabbrev	:ca[bbrev] like `:abbreviate` but for Command-line mode
+cabclear	:cabc[lear] clear all abbreviations for Command-line mode
+caddbuffer	:caddb[uffer] add errors from buffer
+caddexpr	:cad[dexpr] add errors from expr
+caddfile	:caddf[ile] add error message to current quickfix list
+call	:cal[l] call a function
+catch	:cat[ch] part of a :try command
+cbuffer	:cb[uffer] parse error messages and jump to first error
+cc	:cc go to specific error
+cclose	:ccl[ose] close quickfix window
+cd	:cd change directory
+center	:ce[nter] format lines at the center
+cexpr	:cex[pr] read errors from expr and jump to first
+cfile	:cf[ile] read file with error messages and jump to first
+cfirst	:cfir[st] go to the specified error, default first one
+cgetbuffer	:cgetb[uffer] get errors from buffer
+cgetexpr	:cgete[xpr] get errors from expr
+cgetfile	:cg[etfile] read file with error messages
+changes	:cha[nges] print the change list
+chdir	:chd[ir] change directory
+checkpath	:che[ckpath] list included files
+checktime	:checkt[ime] check timestamp of loaded buffers
+clist	:cl[ist] list all errors
+clast	:cla[st] go to the specified error, default last one
+close	:clo[se] close current window
+cmap	:cm[ap] like `:map` but for Command-line mode
+cmapclear	:cmapc[lear] clear all mappings for Command-line mode
+cmenu	:cme[nu] add menu for Command-line mode
+cnext	:cn[ext] go to next error
+cnewer	:cnew[er] go to newer error list
+cnfile	:cnf[ile] go to first error in next file
+cnoremap	:cno[remap] like `:noremap` but for Command-line mode
+cnoreabbrev	:cnorea[bbrev] like `:noreabbrev` but for Command-line mode
+cnoremenu	:cnoreme[nu] like `:noremenu` but for Command-line mode
+copy	:co[py] copy lines
+colder	:col[der] go to older error list
+colorscheme	:colo[rscheme] load a specific color scheme
+command	:com[mand] create user-defined command
+comclear	:comc[lear] clear all user-defined commands
+compiler	:comp[iler] do settings for a specific compiler
+continue	:con[tinue] go back to :while
+confirm	:conf[irm] prompt user when confirmation required
+copen	:cope[n] open quickfix window
+cprevious	:cp[revious] go to previous error
+cpfile	:cpf[ile] go to last error in previous file
+cquit	:cq[uit] quit Vim with an error code
+crewind	:cr[ewind] go to the specified error, default first one
+cscope	:cs[cope] execute cscope command
+cstag	:cst[ag] use cscope to jump to a tag
+cunmap	:cu[nmap] like `:unmap` but for Command-line mode
+cunabbrev	:cuna[bbrev] like `:unabbrev` but for Command-line mode
+cunmenu	:cunme[nu] remove menu for Command-line mode
+cwindow	:cw[indow] open or close quickfix window
+delete	:d[elete] delete lines
+delmarks	:delm[arks] delete marks
+debug	:deb[ug] run a command in debugging mode
+debuggreedy	:debugg[reedy] read debug mode commands from normal input
+delcommand	:delc[ommand] delete user-defined command
+delfunction	:delf[unction] delete a user function
+diffupdate	:dif[fupdate] update 'diff' buffers
+diffget	:diffg[et] remove differences in current buffer
+diffoff	:diffo[ff] switch off diff mode
+diffpatch	:diffp[atch] apply a patch and show differences
+diffput	:diffpu[t] remove differences in other buffer
+diffsplit	:diffs[plit] show differences with another file
+diffthis	:diffthis make current window a diff window
+digraphs	:dig[raphs] show or enter digraphs
+display	:di[splay] display registers
+djump	:dj[ump] jump to #define
+dlist	:dl[ist] list #defines
+doautocmd	:do[autocmd] apply autocommands to current buffer
+doautoall	:doautoa[ll] apply autocommands for all loaded buffers
+drop	:dr[op] jump to window editing file or edit file in current window
+dsearch	:ds[earch] list one #define
+dsplit	:dsp[lit] split window and jump to #define
+edit	:e[dit] edit a file
+earlier	:ea[rlier] go to older change, undo
+echo	:ec[ho] echoes the result of expressions
+echoerr	:echoe[rr] like :echo, show like an error and use history
+echohl	:echoh[l] set highlighting for echo commands
+echomsg	:echom[sg] same as :echo, put message in history
+echon	:echon same as :echo, but without <EOL>
+else	:el[se] part of an :if command
+elseif	:elsei[f] part of an :if command
+emenu	:em[enu] execute a menu by name
+endif	:en[dif] end previous :if
+endfor	:endfo[r] end previous :for
+endfunction	:endf[unction] end of a user function
+endtry	:endt[ry] end previous :try
+endwhile	:endw[hile] end previous :while
+enew	:ene[w] edit a new, unnamed buffer
+ex	:ex same as `:edit`
+execute	:exe[cute] execute result of expressions
+exit	:exi[t] same as `:xit`
+exusage	:exu[sage] overview of Ex commands
+file	:f[ile] show or set the current file name
+files	:files list all files in the buffer list
+filetype	:filet[ype] switch file type detection on/off
+find	:fin[d] find file in 'path' and edit it
+finally	:fina[lly] part of a :try command
+finish	:fini[sh] quit sourcing a Vim script
+first	:fir[st] go to the first file in the argument list
+fixdel	:fix[del] set key code of <Del>
+fold	:fo[ld] create a fold
+foldclose	:foldc[lose] close folds
+folddoopen	:foldd[oopen] execute command on lines not in a closed fold
+folddoclosed	:folddoc[losed] execute command on lines in a closed fold
+foldopen	:foldo[pen] open folds
+for	:for for loop
+function	:fu[nction] define a user function
+global	:g[lobal] execute commands for matching lines
+goto	:go[to] go to byte in the buffer
+grep	:gr[ep] run 'grepprg' and jump to first match
+grepadd	:grepa[dd] like :grep, but append to current list
+gui	:gu[i] start the GUI
+gvim	:gv[im] start the GUI
+hardcopy	:ha[rdcopy] send text to the printer
+help	:h[elp] open a help window
+helpfind	:helpf[ind] dialog to open a help window
+helpgrep	:helpg[rep] like `:grep` but searches help files
+helptags	:helpt[ags] generate help tags for a directory
+highlight	:hi[ghlight] specify highlighting methods
+hide	:hid[e] hide current buffer for a command
+history	:his[tory] print a history list
+insert	:i[nsert] insert text
+iabbrev	:ia[bbrev] like `:abbrev` but for Insert mode
+iabclear	:iabc[lear] like `:abclear` but for Insert mode
+if	:if execute commands when condition met
+ijump	:ij[ump] jump to definition of identifier
+ilist	:il[ist] list lines where identifier matches
+imap	:im[ap] like `:map` but for Insert mode
+imapclear	:imapc[lear] like `:mapclear` but for Insert mode
+imenu	:ime[nu] add menu for Insert mode
+inoremap	:ino[remap] like `:noremap` but for Insert mode
+inoreabbrev	:inorea[bbrev] like `:noreabbrev` but for Insert mode
+inoremenu	:inoreme[nu] like `:noremenu` but for Insert mode
+intro	:int[ro] print the introductory message
+isearch	:is[earch] list one line where identifier matches
+isplit	:isp[lit] split window and jump to definition of identifier
+iunmap	:iu[nmap] like `:unmap` but for Insert mode
+iunabbrev	:iuna[bbrev] like `:unabbrev` but for Insert mode
+iunmenu	:iunme[nu] remove menu for Insert mode
+join	:j[oin] join lines
+jumps	:ju[mps] print the jump list
+k	:k set a mark
+keepalt	:keepa[lt] following command keeps the alternate file
+keepmarks	:kee[pmarks] following command keeps marks where they are
+keepjumps	:keepj[umps] following command keeps jumplist and marks
+lNext	:lN[ext] go to previous entry in location list
+lNfile	:lNf[ile] go to last entry in previous file
+list	:l[ist] print lines
+laddexpr	:lad[dexpr] add locations from expr
+laddbuffer	:laddb[uffer] add locations from buffer
+laddfile	:laddf[ile] add locations to current location list
+last	:la[st] go to the last file in the argument list
+language	:lan[guage] set the language (locale)
+later	:lat[er] go to newer change, redo
+lbuffer	:lb[uffer] parse locations and jump to first location
+lcd	:lc[d] change directory locally
+lchdir	:lch[dir] change directory locally
+lclose	:lcl[ose] close location window
+lcscope	:lcs[cope] like `:cscope` but uses location list
+left	:le[ft] left align lines
+leftabove	:lefta[bove] make split window appear left or above
+let	:let assign a value to a variable or option
+lexpr	:lex[pr] read locations from expr and jump to first
+lfile	:lf[ile] read file with locations and jump to first
+lfirst	:lfir[st] go to the specified location, default first one
+lgetbuffer	:lgetb[uffer] get locations from buffer
+lgetexpr	:lgete[xpr] get locations from expr
+lgetfile	:lg[etfile] read file with locations
+lgrep	:lgr[ep] run 'grepprg' and jump to first match
+lgrepadd	:lgrepa[dd] like :grep, but append to current list
+lhelpgrep	:lh[elpgrep] like `:helpgrep` but uses location list
+ll	:ll go to specific location
+llast	:lla[st] go to the specified location, default last one
+llist	:lli[st] list all locations
+lmake	:lmak[e] execute external command 'makeprg' and parse error messages
+lmap	:lm[ap] like `:map!` but includes Lang-Arg mode
+lmapclear	:lmapc[lear] like `:mapclear!` but includes Lang-Arg mode
+lnext	:lne[xt] go to next location
+lnewer	:lnew[er] go to newer location list
+lnfile	:lnf[ile] go to first location in next file
+lnoremap	:ln[oremap] like `:noremap!` but includes Lang-Arg mode
+loadkeymap	:loadk[eymap] load the following keymaps until EOF
+loadview	:lo[adview] load view for current window from a file
+lockmarks	:loc[kmarks] following command keeps marks where they are
+lockvar	:lockv[ar] lock variables
+lolder	:lol[der] go to older location list
+lopen	:lope[n] open location window
+lprevious	:lp[revious] go to previous location
+lpfile	:lpf[ile] go to last location in previous file
+lrewind	:lr[ewind] go to the specified location, default first one
+ls	:ls list all buffers
+ltag	:lt[ag] jump to tag and add matching tags to the location list
+lunmap	:lu[nmap] like `:unmap!` but includes Lang-Arg mode
+lua	:lua execute Lua command
+luado	:luad[o] execute Lua command for each line
+luafile	:luaf[ile] execute Lua script file
+lvimgrep	:lv[imgrep] search for pattern in files
+lvimgrepadd	:lvimgrepa[dd] like :vimgrep, but append to current list
+lwindow	:lw[indow] open or close location window
+move	:m[ove] move lines
+mark	:ma[rk] set a mark
+make	:mak[e] execute external command 'makeprg' and parse error messages
+map	:map show or enter a mapping
+mapclear	:mapc[lear] clear all mappings for Normal and Visual mode
+marks	:marks list all marks
+match	:mat[ch] define a match to highlight
+menu	:me[nu] enter a new menu item
+menutranslate	:menut[ranslate] add a menu translation item
+messages	:mes[sages] view previously displayed messages
+mkexrc	:mk[exrc] write current mappings and settings to a file
+mksession	:mks[ession] write session info to a file
+mkspell	:mksp[ell] produce .spl spell file
+mkvimrc	:mkv[imrc] write current mappings and settings to a file
+mkview	:mkvie[w] write view of current window to a file
+mode	:mod[e] show or change the screen mode
+mzscheme	:mz[scheme] execute MzScheme command
+mzfile	:mzf[ile] execute MzScheme script file
+nbclose	:nbc[lose] close the current Netbeans session
+nbkey	:nb[key] pass a key to Netbeans
+nbstart	:nbs[art] start a new Netbeans session
+next	:n[ext] go to next file in the argument list
+new	:new create a new empty window
+nmap	:nm[ap] like `:map` but for Normal mode
+nmapclear	:nmapc[lear] clear all mappings for Normal mode
+nmenu	:nme[nu] add menu for Normal mode
+nnoremap	:nn[oremap] like `:noremap` but for Normal mode
+nnoremenu	:nnoreme[nu] like `:noremenu` but for Normal mode
+noautocmd	:noa[utocmd] following command don't trigger autocommands
+noremap	:no[remap] enter a mapping that will not be remapped
+nohlsearch	:noh[lsearch] suspend 'hlsearch' highlighting
+noreabbrev	:norea[bbrev] enter an abbreviation that will not be remapped
+noremenu	:noreme[nu] enter a menu that will not be remapped
+normal	:norm[al] execute Normal mode commands
+number	:nu[mber] print lines with line number
+nunmap	:nun[map] like `:unmap` but for Normal mode
+nunmenu	:nunme[nu] remove menu for Normal mode
+oldfiles	:ol[dfiles] list files that have marks in the viminfo file
+open	:o[pen] start open mode (not implemented)
+omap	:om[ap] like `:map` but for Operator-pending mode
+omapclear	:omapc[lear] remove all mappings for Operator-pending mode
+omenu	:ome[nu] add menu for Operator-pending mode
+only	:on[ly] close all windows except the current one
+onoremap	:ono[remap] like `:noremap` but for Operator-pending mode
+onoremenu	:onoreme[nu] like `:noremenu` but for Operator-pending mode
+options	:opt[ions] open the options-window
+ounmap	:ou[nmap] like `:unmap` but for Operator-pending mode
+ounmenu	:ounme[nu] remove menu for Operator-pending mode
+ownsyntax	:ow[nsyntax] set new local syntax highlight for this window
+pclose	:pc[lose] close preview window
+pedit	:ped[it] edit file in the preview window
+perl	:pe[rl] execute Perl command
+print	:p[rint] print lines
+profdel	:profd[el] stop profiling a function or script
+profile	:prof[ile] profiling functions and scripts
+promptfind	:pro[mptfind] open GUI dialog for searching
+promptrepl	:promptr[epl] open GUI dialog for search/replace
+perldo	:perld[o] execute Perl command for each line
+pop	:po[p] jump to older entry in tag stack
+popup	:pop[up] popup a menu by name
+ppop	:pp[op] `:pop` in preview window
+preserve	:pre[serve] write all text to swap file
+previous	:prev[ious] go to previous file in argument list
+psearch	:ps[earch] like `:ijump` but shows match in preview window
+ptag	:pt[ag] show tag in preview window
+ptNext	:ptN[ext] :tNext in preview window
+ptfirst	:ptf[irst] :trewind in preview window
+ptjump	:ptj[ump] :tjump and show tag in preview window
+ptlast	:ptl[ast] :tlast in preview window
+ptnext	:ptn[ext] :tnext in preview window
+ptprevious	:ptp[revious] :tprevious in preview window
+ptrewind	:ptr[ewind] :trewind in preview window
+ptselect	:pts[elect] :tselect and show tag in preview window
+put	:pu[t] insert contents of register in the text
+pwd	:pw[d] print current directory
+py3	:py3 execute Python 3 command
+python3	:python3 same as :py3
+py3file	:py3f[ile] execute Python 3 script file
+python	:py[thon] execute Python command
+pyfile	:pyf[ile] execute Python script file
+quit	:q[uit] quit current window (when one window quit Vim)
+quitall	:quita[ll] quit Vim
+qall	:qa[ll] quit Vim
+read	:r[ead] read file into the text
+recover	:rec[over] recover a file from a swap file
+redo	:red[o] redo one undone change
+redir	:redi[r] redirect messages to a file or register
+redraw	:redr[aw] force a redraw of the display
+redrawstatus	:redraws[tatus] force a redraw of the status line(s)
+registers	:reg[isters] display the contents of registers
+resize	:res[ize] change current window height
+retab	:ret[ab] change tab size
+return	:retu[rn] return from a user function
+rewind	:rew[ind] go to the first file in the argument list
+right	:ri[ght] right align text
+rightbelow	:rightb[elow] make split window appear right or below
+ruby	:rub[y] execute Ruby command
+rubydo	:rubyd[o] execute Ruby command for each line
+rubyfile	:rubyf[ile] execute Ruby script file
+rundo	:rund[o] read undo information from a file
+runtime	:ru[ntime] source vim scripts in 'runtimepath'
+rviminfo	:rv[iminfo] read from viminfo file
+substitute	:s[ubstitute] find and replace text
+sNext	:sN[ext] split window and go to previous file in argument list
+sandbox	:san[dbox] execute a command in the sandbox
+sargument	:sa[rgument] split window and go to specific file in argument list
+sall	:sal[l] open a window for each file in argument list
+saveas	:sav[eas] save file under another name.
+sbuffer	:sb[uffer] split window and go to specific file in the buffer list
+sbNext	:sbN[ext] split window and go to previous file in the buffer list
+sball	:sba[ll] open a window for each file in the buffer list
+sbfirst	:sbf[irst] split window and go to first file in the buffer list
+sblast	:sbl[ast] split window and go to last file in buffer list
+sbmodified	:sbm[odified] split window and go to modified file in the buffer list
+sbnext	:sbn[ext] split window and go to next file in the buffer list
+sbprevious	:sbp[revious] split window and go to previous file in the buffer list
+sbrewind	:sbr[ewind] split window and go to first file in the buffer list
+scriptnames	:scrip[tnames] list names of all sourced Vim scripts
+scriptencoding	:scripte[ncoding] encoding used in sourced Vim script
+scscope	:scs[cope] split window and execute cscope command
+set	:se[t] show or set options
+setfiletype	:setf[iletype] set 'filetype', unless it was set already
+setglobal	:setg[lobal] show global values of options
+setlocal	:setl[ocal] show or set options locally
+sfind	:sf[ind] split current window and edit file in 'path'
+sfirst	:sfir[st] split window and go to first file in the argument list
+shell	:sh[ell] escape to a shell
+simalt	:sim[alt] Win32 GUI: simulate Windows ALT key
+sign	:sig[n] manipulate signs
+silent	:sil[ent] run a command silently
+sleep	:sl[eep] do nothing for a few seconds
+slast	:sla[st] split window and go to last file in the argument list
+smagic	:sm[agic] :substitute with 'magic'
+smap	:sma[p] like `:map` but for Select mode
+smapclear	:smapc[lear] remove all mappings for Select mode
+smenu	:sme[nu] add menu for Select mode
+snext	:sn[ext] split window and go to next file in the argument list
+sniff	:sni[ff] send request to sniff
+snomagic	:sno[magic] :substitute with 'nomagic'
+snoremap	:snor[emap] like `:noremap` but for Select mode
+snoremenu	:snoreme[nu] like `:noremenu` but for Select mode
+sort	:sor[t] sort lines
+source	:so[urce] read Vim or Ex commands from a file
+spelldump	:spelld[ump] split window and fill with all correct words
+spellgood	:spe[llgood] add good word for spelling
+spellinfo	:spelli[nfo] show info about loaded spell files
+spellrepall	:spellr[epall] replace all bad words like last z=
+spellundo	:spellu[ndo] remove good or bad word
+spellwrong	:spellw[rong] add spelling mistake
+split	:sp[lit] split current window
+sprevious	:spr[evious] split window and go to previous file in the argument list
+srewind	:sre[wind] split window and go to first file in the argument list
+stop	:st[op] suspend the editor or escape to a shell
+stag	:sta[g] split window and jump to a tag
+startinsert	:star[tinsert] start Insert mode
+startgreplace	:startg[replace] start Virtual Replace mode
+startreplace	:startr[eplace] start Replace mode
+stopinsert	:stopi[nsert] stop Insert mode
+stjump	:stj[ump] do `:tjump` and split window
+stselect	:sts[elect] do `:tselect` and split window
+sunhide	:sun[hide] same as `:unhide`
+sunmap	:sunm[ap] like `:unmap` but for Select mode
+sunmenu	:sunme[nu] remove menu for Select mode
+suspend	:sus[pend] same as `:stop`
+sview	:sv[iew] split window and edit file read-only
+swapname	:sw[apname] show the name of the current swap file
+syntax	:sy[ntax] syntax highlighting
+syncbind	:sync[bind] sync scroll binding
+t	:t same as `:copy`
+tNext	:tN[ext] jump to previous matching tag
+tabNext	:tabN[ext] go to previous tab page
+tabclose	:tabc[lose] close current tab page
+tabdo	:tabdo execute command in each tab page
+tabedit	:tabe[dit] edit a file in a new tab page
+tabfind	:tabf[ind] find file in 'path', edit it in a new tab page
+tabfirst	:tabfir[st] got to first tab page
+tablast	:tabl[ast] got to last tab page
+tabmove	:tabm[ove] move tab page to other position
+tabnew	:tabnew edit a file in a new tab page
+tabnext	:tabn[ext] go to next tab page
+tabonly	:tabo[nly] close all tab pages except the current one
+tabprevious	:tabp[revious] go to previous tab page
+tabrewind	:tabr[ewind] got to first tab page
+tabs	:tabs list the tab pages and what they contain
+tab	:tab create new tab when opening new window
+tag	:ta[g] jump to tag
+tags	:tags show the contents of the tag stack
+tcl	:tc[l] execute Tcl command
+tcldo	:tcld[o] execute Tcl command for each line
+tclfile	:tclf[ile] execute Tcl script file
+tearoff	:te[aroff] tear-off a menu
+tfirst	:tf[irst] jump to first matching tag
+throw	:th[row] throw an exception
+tjump	:tj[ump] like `:tselect`, but jump directly when there is only one match
+tlast	:tl[ast] jump to last matching tag
+tmenu	:tm[enu] define menu tooltip
+tnext	:tn[ext] jump to next matching tag
+topleft	:to[pleft] make split window appear at top or far left
+tprevious	:tp[revious] jump to previous matching tag
+trewind	:tr[ewind] jump to first matching tag
+try	:try execute commands, abort on error or exception
+tselect	:ts[elect] list matching tags and select one
+tunmenu	:tu[nmenu] remove menu tooltip
+undo	:u[ndo] undo last change(s)
+undojoin	:undoj[oin] join next change with previous undo block
+undolist	:undol[ist] list leafs of the undo tree
+unabbreviate	:una[bbreviate] remove abbreviation
+unhide	:unh[ide] open a window for each loaded file in the buffer list
+unlet	:unl[et] delete variable
+unlockvar	:unlo[ckvar] unlock variables
+unmap	:unm[ap] remove mapping
+unmenu	:unme[nu] remove menu
+unsilent	:uns[ilent] run a command not silently
+update	:up[date] write buffer if modified
+vglobal	:v[global] execute commands for not matching lines
+version	:ve[rsion] print version number and other info
+verbose	:verb[ose] execute command with 'verbose' set
+vertical	:vert[ical] make following command split vertically
+vimgrep	:vim[grep] search for pattern in files
+vimgrepadd	:vimgrepa[dd] like :vimgrep, but append to current list
+visual	:vi[sual] same as `:edit`, but turns off `Ex` mode
+viusage	:viu[sage] overview of Normal mode commands
+view	:vie[w] edit a file read-only
+vmap	:vm[ap] like `:map` but for Visual+Select mode
+vmapclear	:vmapc[lear] remove all mappings for Visual+Select mode
+vmenu	:vme[nu] add menu for Visual+Select mode
+vnew	:vne[w] create a new empty window, vertically split
+vnoremap	:vn[oremap] like `:noremap` but for Visual+Select mode
+vnoremenu	:vnoreme[nu] like `:noremenu` but for Visual+Select mode
+vsplit	:vs[plit] split current window vertically
+vunmap	:vu[nmap] like `:unmap` but for Visual+Select mode
+vunmenu	:vunme[nu] remove menu for Visual+Select mode
+windo	:windo execute command in each window
+write	:w[rite] write to a file
+wNext	:wN[ext] write to a file and go to previous file in argument list
+wall	:wa[ll] write all (changed) buffers
+while	:wh[ile] execute loop for as long as condition met
+winsize	:wi[nsize] get or set window size (obsolete)
+wincmd	:winc[md] execute a Window (CTRL-W) command
+winpos	:winp[os] get or set window position
+wnext	:wn[ext] write to a file and go to next file in argument list
+wprevious	:wp[revious] write to a file and go to previous file in argument list
+wq	:wq write to a file and quit window or Vim
+wqall	:wqa[ll] write all changed buffers and quit Vim
+wsverb	:ws[verb] pass the verb to workshop over IPC
+wundo	:wu[ndo] write undo information to a file
+wviminfo	:wv[iminfo] write to viminfo file
+xit	:x[it] write if buffer changed and quit window or Vim
+xall	:xa[ll] same as `:wqall`
+xmapclear	:xmapc[lear] remove all mappings for Visual mode
+xmap	:xm[ap] like `:map` but for Visual mode
+xmenu	:xme[nu] add menu for Visual mode
+xnoremap	:xn[oremap] like `:noremap` but for Visual mode
+xnoremenu	:xnoreme[nu] like `:noremenu` but for Visual mode
+xunmap	:xu[nmap] like `:unmap` but for Visual mode
+xunmenu	:xunme[nu] remove menu for Visual mode
+yank	:y[ank] yank lines into a register
+z	:z print some lines
+~	:~ repeat last `:substitute`


### PR DESCRIPTION
The script used to use `vim.eval("add ...")` to add commands one by one, which causes the first search quite slow (around 2s on my macbook pro). The best solution would be to use `vim.bindeval` feature in Vim7.4 to init `s:cmdpalette_commands`. But that will make this plugin incompatible with < 7.4 and Neovim. My fix is to use `json.dumps` to serialize all commands and set `s:cmdpalette_commands` with one `vim.command`. The result is fast enough that I couldn't notice any lag.