### PR TITLE
enter input mode when press ctrl-[xvt]

### DIFF
--- a/autoload/ctrlp/cmdpalette.vim
+++ b/autoload/ctrlp/cmdpalette.vim
@@ -100,11 +100,12 @@ func! ctrlp#cmdpalette#accept(mode, str)
   redraw
   call feedkeys(':', 'n')
   call feedkeys(split(a:str, '\t')[0], 'n')
-  if g:ctrlp_cmdpalette_execute == 1
+  if a:mode == 'e' && g:ctrlp_cmdpalette_execute == 1
     call feedkeys("\<CR>", 'n')
   endif
   call remove(s:cmdpalette_commands, index(s:cmdpalette_commands, a:str))
   call insert(s:cmdpalette_commands, a:str)
+	call feedkeys(" ", 'n')
 endfunc
 
 

--- a/autoload/ctrlp/cmdpalette.vim
+++ b/autoload/ctrlp/cmdpalette.vim
@@ -98,6 +98,8 @@ endfunction
 func! ctrlp#cmdpalette#accept(mode, str)
   call ctrlp#exit()
   redraw
+  let g:ctrlp_open_mode = a:mode
+  let g:ctrlp_open_cmd = a:str
   call feedkeys(':', 'n')
   call feedkeys(split(a:str, '\t')[0], 'n')
   if a:mode == 'e' && g:ctrlp_cmdpalette_execute == 1

--- a/autoload/ctrlp/cmdpalette.vim
+++ b/autoload/ctrlp/cmdpalette.vim
@@ -104,12 +104,11 @@ func! ctrlp#cmdpalette#accept(mode, str)
   call feedkeys(split(a:str, '\t')[0], 'n')
   if a:mode == 'e' && g:ctrlp_cmdpalette_execute == 1
     call feedkeys("\<CR>", 'n')
+  else
+    call feedkeys(" ", 'n')
   endif
   call remove(s:cmdpalette_commands, index(s:cmdpalette_commands, a:str))
   call insert(s:cmdpalette_commands, a:str)
-	if a:mode != 'e'
-		call feedkeys(" ", 'n')
-	endif
 endfunc
 
 

--- a/autoload/ctrlp/cmdpalette.vim
+++ b/autoload/ctrlp/cmdpalette.vim
@@ -105,7 +105,9 @@ func! ctrlp#cmdpalette#accept(mode, str)
   endif
   call remove(s:cmdpalette_commands, index(s:cmdpalette_commands, a:str))
   call insert(s:cmdpalette_commands, a:str)
-	call feedkeys(" ", 'n')
+	if a:mode != 'e'
+		call feedkeys(" ", 'n')
+	endif
 endfunc
 
 


### PR DESCRIPTION
Provide a way to enter input mode even with `let g:ctrlp_cmdpalette_execute = 1` set.